### PR TITLE
Pass the scale option through to the tilelive source when loading

### DIFF
--- a/lib/commands/render.js
+++ b/lib/commands/render.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var fs = require("fs");
+var fs = require("fs"),
+    url = require("url");
 
 var abaculus = require("abaculus");
 
@@ -90,7 +91,10 @@ module.exports = function(parser, tilelive) {
 
       require("../modules")(tilelive, opts);
 
-      return tilelive.load(opts.source, function(err, source) {
+      var source = url.parse(opts.source, true);
+      source.query.scale = source.query.scale || opts.scale;
+
+      return tilelive.load(source, function(err, source) {
         if (err) {
           throw err;
         }


### PR DESCRIPTION
When rendering a tmstyle at scale 2, the tiles were still being rendered with a scale of 1.  
e.g.
    tl render tmstyle://style --scale 2 -z 12 -c "-0.127758 51.507351" -d "500 500" -o image.png

produced:

![zoom-12a](https://cloud.githubusercontent.com/assets/12736/9561402/e7f07be0-4e3b-11e5-8de6-01c7ac6b353e.png)

This change passes the scale option through the source when it is loaded, which means it now produces:

![zoom-12](https://cloud.githubusercontent.com/assets/12736/9561403/f1b1d0d4-4e3b-11e5-8b60-af2d225b3b68.png)

The datasource of the tmstyle that I was using was vector tiles served over http by tessera.
